### PR TITLE
fix info in make's help target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ help:
 	@echo ""
 	@echo "Available commands are:"
 	@echo "	make fast		- to build KACTL, quickly (only runs LaTeX once)"
-	@echo "	make kactl		- to build KACTL"
+	@echo "	make hackpack	- to build KACTL"
 	@echo "	make clean		- to clean up the build process"
 	@echo "	make veryclean		- to clean up and remove kactl.pdf"
 	@echo "	make test		- to run all the stress tests in stress-tests/"


### PR DESCRIPTION
### Summary
running `make help` echos incorrect build target (it was changed from `kactl` to `hackpack`)

(It looks like https://github.com/UCF-OrElse/hackpack-v2/pull/75 was resolved but not https://github.com/UCF-OrElse/hackpack-v2/pull/74 yet.)

### Checklist
- [ ] ~~AC on at least 1 problem~~ (N/A)
- [x] Using tabs for indentation
- [x] Longest line at most 63 characters (with tab length 2)
